### PR TITLE
Add default working directory setup

### DIFF
--- a/elisa_app.py
+++ b/elisa_app.py
@@ -15,6 +15,13 @@ GOOGLE_CREDENTIALS = 'credentials.json'
 GOOGLE_SHEET_NAME = 'ElisaData'
 
 
+def ensure_working_directory():
+    """Ensure default working directory exists and switch to it."""
+    target = os.path.join(os.path.expanduser('~'), 'projects', 'ELISA')
+    os.makedirs(target, exist_ok=True)
+    os.chdir(target)
+
+
 def init_db():
     conn = sqlite3.connect(DB_FILE)
     cursor = conn.cursor()
@@ -141,6 +148,7 @@ if __name__ == '__main__':
     parser.add_argument('--fetch-online', action='store_true', help='Show results from Google Sheets')
     args = parser.parse_args()
 
+    ensure_working_directory()
     init_db()
 
     if args.add:

--- a/elisa_gui.py
+++ b/elisa_gui.py
@@ -17,6 +17,13 @@ GOOGLE_CREDENTIALS = 'credentials.json'
 GOOGLE_SHEET_NAME = 'ElisaData'
 
 
+def ensure_working_directory():
+    """Ensure default working directory exists and switch to it."""
+    target = os.path.join(os.path.expanduser('~'), 'projects', 'ELISA')
+    os.makedirs(target, exist_ok=True)
+    os.chdir(target)
+
+
 # Database initialization with category support
 def init_db():
     conn = sqlite3.connect(DB_FILE)
@@ -298,4 +305,5 @@ class App(tk.Tk):
 
 
 if __name__ == '__main__':
+    ensure_working_directory()
     App().mainloop()


### PR DESCRIPTION
## Summary
- create `ensure_working_directory` utility in both CLI and GUI scripts
- call the utility before initializing the DB or launching the GUI

## Testing
- `python -m py_compile elisa_app.py elisa_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_686829348d948328908899efb06995dc